### PR TITLE
fix(config): add replit.nix config

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,20 @@
+{ pkgs }: {
+  deps = [
+    pkgs.python38Full
+    pkgs.python38Packages.pandas
+    pkgs.python38Packages.scipy
+  ];
+  env = {
+    PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+      # Needed for pandas / numpy
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      # Needed for pygame
+      pkgs.glib
+      # Needed for matplotlib
+      pkgs.xorg.libX11
+    ];
+    PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
+    LANG = "en_US.UTF-8";
+  };
+}

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,7 @@
 { pkgs }: {
   deps = [
     pkgs.python38Full
+    pkgs.python38Packages.matplotlib
     pkgs.python38Packages.pandas
     pkgs.python38Packages.scipy
   ];


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
- Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/46824
- Adds `replit.nix` file with required package. This appears to work out of the box.
- Replit in the examples and their python template doesn't install python modules like that. However when changing new _blank_ and existing _python_ replits, to try to use their approach I wasn't able to make it work. After copying their `.replit` and `replit.nix` file, installing required modules still didn't work. Unless new replit was started with their _python_ template there were errors with installing modules. I do not understand why the same exact config is not giving the same results, when replit is _started_ differently, and otherwise has the same files.