### PR TITLE
fix: bump Python version to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ description = ""
 
 [tool.poetry.dependencies]
 pandas = "*"
-python = "^3.7"
+python = "^3.8"
 scipy = "*"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently there's an issue installing all the necessary packages when after importing this project onto Replit.

Bumping the Python version to `^3.8` in `pyproject.toml` seems to fix that.

Here are some steps for testing:

- Clone this project onto Replit using this link: https://replit.com/github/freeCodeCamp/boilerplate-sea-level-predictor
- In the `.replit` window, select `Use run command` and click the `Done` button
- Open the `pyproject.toml` file and change `python = "^3.7"` to `python = "^3.8"` on line 10
- Click the green `Run` button at the top of the page